### PR TITLE
Add header and footer to menu category

### DIFF
--- a/src/Components/Menu-List/Menu.jsx
+++ b/src/Components/Menu-List/Menu.jsx
@@ -2,19 +2,22 @@ import React, { Component } from 'react'
 import menu from '../../CommonResource/data'
 import FoodItem from '../Food Items/FoodItem'
 import style from './Menu.module.css'
+import MenuHeader from './MenuHeader'
+import MenuFooter from './MenuFooter'
 
 export default class Menu extends Component {
   render() {
     return (
 
 <div className={style["foods-container"]}>
+<MenuHeader />
 {menu.map((menus)=>
   (
        <FoodItem key={menus.id} {...menus} />
     )
    
 )}
-
+<MenuFooter />
 </div>
     
     )

--- a/src/Components/Menu-List/MenuFooter.jsx
+++ b/src/Components/Menu-List/MenuFooter.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './MenuFooter.module.css';
+
+const MenuFooter = () => {
+  return (
+    <p className={styles.menuFooter}>Enjoy your meal!</p>
+  );
+};
+
+export default MenuFooter;

--- a/src/Components/Menu-List/MenuFooter.module.css
+++ b/src/Components/Menu-List/MenuFooter.module.css
@@ -1,0 +1,6 @@
+.menuFooter {
+  background-color: #e0e0e0;
+  padding: 8px;
+  text-align: center;
+  font-style: italic;
+}

--- a/src/Components/Menu-List/MenuHeader.jsx
+++ b/src/Components/Menu-List/MenuHeader.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './MenuHeader.module.css';
+
+const MenuHeader = () => {
+  return (
+    <h2 className={styles.menuHeader}>Menu Category</h2>
+  );
+};
+
+export default MenuHeader;

--- a/src/Components/Menu-List/MenuHeader.module.css
+++ b/src/Components/Menu-List/MenuHeader.module.css
@@ -1,0 +1,5 @@
+.menuHeader {
+  background-color: #f0f0f0;
+  padding: 10px;
+  text-align: center;
+}


### PR DESCRIPTION
This commit introduces a header and footer to the menu category display.

- I created a new `MenuHeader.jsx` component to display a title for the menu category.
- I created a new `MenuFooter.jsx` component to display a closing message.
- I modified `Menu.jsx` to incorporate these new header and footer components.
- I added basic CSS module styling for `MenuHeader` and `MenuFooter` for visual distinction.